### PR TITLE
Use tagmaps instead of taglists, show tags on image click.

### DIFF
--- a/web/src/components/SearchSideBar/SearchSideBar.tsx
+++ b/web/src/components/SearchSideBar/SearchSideBar.tsx
@@ -1,13 +1,14 @@
 import React, { useState }  from 'react';
-import styles               from './SearchSideBar.module.css';
+import { tags }             from '../../types/image';
 
 import IconButton           from '../IconButton';
 import panels, { PanelMap } from './panels';
 import TextInput            from '../TextInput';
+import styles               from './SearchSideBar.module.css';
 
 
 interface Props {
-    tags?: string[];
+    tags?: tags;
     initialPanel: string;
     children?: PanelMap;
 }

--- a/web/src/components/SearchSideBar/panels/TagPanel.tsx
+++ b/web/src/components/SearchSideBar/panels/TagPanel.tsx
@@ -1,10 +1,12 @@
 import React             from 'react';
+import { tags }          from '../../../types/image';
+
 import Attribute         from '../../../components/Attribute';
 import styles            from './TagPanel.module.css';
 
 
 interface Props {
-    tags?: string[];
+    tags?: tags;
 }
 
 export default {
@@ -16,8 +18,18 @@ export default {
             <h1>Taglist</h1>
             <div className={styles.TagList}>
                 {
-                    !props.tags ? null : props.tags.map(tag => (
-                        <Attribute key={tag} icon="tag" name={tag} value="1" />
+                    props.tags && Object.keys(props.tags).map(tag => (
+                        <Attribute
+                            key={tag}
+                            icon="tag"
+                            name={tag}
+                            value={(
+                                props.tags &&
+                                props.tags[tag] > 1 &&
+                                String(props.tags[tag])
+                            ) || ''
+                            }
+                        />
                     ))
                 }
             </div>

--- a/web/src/screens/ImageGalleries/ImageGalleries.tsx
+++ b/web/src/screens/ImageGalleries/ImageGalleries.tsx
@@ -41,7 +41,7 @@ const Image = (props: Props) => {
 
             <div className={styles.Root}>
                 <SearchSidebar
-                    tags={onlyImage.tags}
+                    tags={{}}
                     initialPanel="metadata"
                 >
                     {{

--- a/web/src/screens/ImageView/ImageView.tsx
+++ b/web/src/screens/ImageView/ImageView.tsx
@@ -29,9 +29,8 @@ const Image = (props: Props) => {
         props.fetchImages()
     }, []);
 
-    const image = props.images.find(image => {
-        return image.UUID === props.match.params.uuid;
-    });
+    const image = props.images.find(image => image.UUID === props.match.params.uuid);
+    const tags  = image && image.tags.reduce((o, tag) => ({ [tag]: 1, ...o }), {})
 
     return !image
         ? <span>Ruh oh</span>
@@ -41,8 +40,8 @@ const Image = (props: Props) => {
 
             <div className={styles.Root}>
                 <SearchSidebar
-                    tags={image.tags}
-                    initialPanel="metadata"
+                    tags={tags}
+                    initialPanel="tags"
                 >
                     {{
                        metadata: MetaDataPanel

--- a/web/src/screens/Index/Index.tsx
+++ b/web/src/screens/Index/Index.tsx
@@ -39,11 +39,34 @@ interface Props {
     match:              match<Params>;
 }
 
+const filterVisibleTags = (images: image[]) => {
+    let tagCounter: { [index: string]: number } = {};
+    images.forEach(image => {
+        image.tags.forEach(tag => {
+            tagCounter[tag] = tag in tagCounter
+                ? tagCounter[tag] + 1
+                : 1
+        });
+    });
+
+    return tagCounter;
+};
+
 const Index = (props: Props) => {
+    // Page Handling
     const pageNumber = parseInt(props.match.params.page || '1', 10);
     const changePage = (page: number) => {
         props.history.push(`/my/images/${page}`)
     };
+
+    // Grid Display Configuration
+    const rows       = 4;
+    const width      = 6;
+    const slice      = props.images.slice(
+        width * rows * (pageNumber - 1 + 0),
+        width * rows * (pageNumber - 1 + 1)
+    );
+    const tags       = filterVisibleTags(slice);
 
     // Load Images, On First Mount Only
     useEffect(() => {
@@ -61,13 +84,13 @@ const Index = (props: Props) => {
                     setScalingMode={props.setGalleryScaling}
                     images={props.images}
                     page={pageNumber}
-                    rows={4}
-                    width={6}
+                    rows={rows}
+                    width={width}
                 />
             </div>
         </div>
     );
-}
+};
 
 const mapState = (state: State) => ({
     images:             getImages(state.images),

--- a/web/src/screens/Index/components/ImageGrid/ImageGrid.tsx
+++ b/web/src/screens/Index/components/ImageGrid/ImageGrid.tsx
@@ -8,6 +8,7 @@ import Image              from '../Image';
 import Pager              from '../Pager';
 import styles             from './ImageGrid.module.css';
 
+
 // HACK, BIG HACK
 const findApiBase = () => {
     const cookies = new Cookies();

--- a/web/src/types/image.tsx
+++ b/web/src/types/image.tsx
@@ -6,3 +6,7 @@ export interface image {
     uploader:   string;
     path:       string;
 }
+
+export interface tags {
+    [index: string]: number
+}


### PR DESCRIPTION
Closes #17, showing tag counts only when necessary, sorting properly, and passing through the right data to images as well.