### PR TITLE
Make API token configureable temporarily until auth.

### DIFF
--- a/web/src/api/images.tsx
+++ b/web/src/api/images.tsx
@@ -18,30 +18,37 @@ const findApiBase = () => {
     return cookies.get('api') || 'http://localhost:3001';
 };
 
+const findApiToken = () => {
+    const cookies = new Cookies();
+    return cookies.get('token') || '96033b4a-44b0-4c14-ac44-890330b9877e';
+};
+
 // Fetch paginated images from the back-end when viewing a gallery. This only
 // returns JSON data _about_ images, the images themselves are still loaded
 // by standard <img> / background-url in various components.
 const getImages = async (): Promise<GetImageResponse> => {
+    const base    = findApiBase();
+    const token   = findApiToken();
     const request = {
-        headers: { 'Authorization': '96033b4a-44b0-4c14-ac44-890330b9877e' },
+        headers: { 'Authorization': token },
         method:  'GET',
     };
 
-    const base      = findApiBase();
-    const response  = await fetch(`${base}/api/image`, request);
-    const json      = await response.json();
+    const response = await fetch(`${base}/api/image`, request);
+    const json     = await response.json();
     return await json;
 }
 
 // Send a list of tags to remove from an image. Removing tags that aren't
 // already on the image does nothing.
 const deleteTags = async (uuid: string, req: DeleteTagsRequest): Promise<void> => {
+    const base    = findApiBase();
+    const token   = findApiToken();
     const request = {
-        headers: { 'Authorization': '96033b4a-44b0-4c14-ac44-890330b9877e' },
+        headers: { 'Authorization': token },
         method:  'POST',
     };
 
-    const base = findApiBase();
     fetch(`${base}/api/image/${uuid}/tags`, request);
 }
 
@@ -49,12 +56,13 @@ const deleteTags = async (uuid: string, req: DeleteTagsRequest): Promise<void> =
 // on pages where we already cached the image data but still want up to date
 // tags, such as image editing.
 const getTags = async (uuid: string): Promise<GetTagsResponse> => {
+    const base    = findApiBase();
+    const token   = findApiToken();
     const request = {
-        headers: { 'Authorization': '96033b4a-44b0-4c14-ac44-890330b9877e' },
+        headers: { 'Authorization': token },
         method:  'GET',
     };
 
-    const base     = findApiBase();
     const response = await fetch(`${base}/api/image/${uuid}/tags`, request);
     const json     = await response.json();
     return await json;
@@ -63,25 +71,27 @@ const getTags = async (uuid: string): Promise<GetTagsResponse> => {
 // Upload a new Image, this is done through a FormData object rather than
 // JSON using multipart/form-data to upload the images.
 const uploadImage = async (req: FormData): Promise<Response> => {
+    const base    = findApiBase();
+    const token   = findApiToken();
     const request = {
-        headers: { 'Authorization': '96033b4a-44b0-4c14-ac44-890330b9877e' },
+        headers: { 'Authorization': token },
         method:  'POST',
         body:    req
     };
 
-    const base = findApiBase();
     return fetch(`${base}/api/image`, request);
 }
 
 // Send new tags to attach to an image, any tags that already exist on the
 // image are ignored.
 const uploadTags = async (uuid: string, req: PostTagsRequest): Promise<void> => {
+    const base    = findApiBase();
+    const token   = findApiToken();
     const request = {
-        headers: { 'Authorization': '96033b4a-44b0-4c14-ac44-890330b9877e' },
+        headers: { 'Authorization': token },
         method:  'POST',
     };
 
-    const base = findApiBase();
     fetch(`${base}/api/image/${uuid}/tags`, request);
 }
 


### PR DESCRIPTION
Until proper authentication is implemented, grab token from a cookie as a holdover for tracking current actions.