### PR TITLE
Make CORS Origin Configureable via Environment

### DIFF
--- a/src/app/Commands/Run.hs
+++ b/src/app/Commands/Run.hs
@@ -43,7 +43,7 @@ run _ = do
     { _configStaticLocation = readTextEnv "PIXEL_STATIC" "tmp/"
     , _configPort           = readNumericEnv "PIXEL_PORT" 6666
     , _configReadSchema     = pure readSchema
-    , _configClientAddress  = readTextEnv "PIXEL_CLIENT_ADDRESS" "localhost:3000"
+    , _configClientAddress  = readTextEnv "PIXEL_CLIENT_ADDRESS" "http://localhost:3000"
     , _configConnection     = pure
         . hookMiddleware (handleProjections readSchema)
         $ makeSQLite3Backend writeSchema

--- a/src/app/Commands/Run.hs
+++ b/src/app/Commands/Run.hs
@@ -38,21 +38,12 @@ run _ = do
   readSchema  <- open "pixel.db"
   writeSchema <- open "event.db"
 
-  -- Configure Authentication Requirements
-  -- jwtKey     <- generateKey
-  -- let jwt     = defaultJWTSettings jwtKey
-  -- let cookies =
-  --       defaultCookieSettings
-  --         :. jwt
-  --         :. EmptyContext
-
   -- Create Parsed Configuration
   config <- readConfig $ Config
     { _configStaticLocation = readTextEnv "PIXEL_STATIC" "tmp/"
     , _configPort           = readNumericEnv "PIXEL_PORT" 6666
     , _configReadSchema     = pure readSchema
-    -- , _configJWT            = jwt
-    -- , _configCookies        = cookies
+    , _configClientAddress  = readTextEnv "PIXEL_CLIENT_ADDRESS" "localhost:3000"
     , _configConnection     = pure
         . hookMiddleware (handleProjections readSchema)
         $ makeSQLite3Backend writeSchema

--- a/src/app/Configuration.hs
+++ b/src/app/Configuration.hs
@@ -5,6 +5,7 @@ module Configuration
   , configPort
   , configReadSchema
   , configStaticLocation
+  , configClientAddress
   , readConfig
   , readNumericEnv
   , readTextEnv
@@ -29,8 +30,7 @@ data Config' f = Config
   , _configPort           :: HKD f Int
   , _configConnection     :: HKD f BackendStore
   , _configReadSchema     :: HKD f Connection
-  -- , _configJWT            :: HKD f JWT
-  -- , _configCookies        :: HKD f Cookies
+  , _configClientAddress  :: HKD f Text
   }
 
 -- Concrete Configuration
@@ -50,8 +50,7 @@ readConfig Config {..} =
     <*> _configPort
     <*> _configConnection
     <*> _configReadSchema
-    -- <*> _configJWT
-    -- <*> _configCookies
+    <*> _configClientAddress
 
 -- Environment Reading Helpers
 --

--- a/src/app/Server.hs
+++ b/src/app/Server.hs
@@ -8,7 +8,7 @@ module Server
 import Protolude
 import Servant
 
-import Configuration                        ( Config(..) )
+import Configuration                        ( Config, Config'(..) )
 import Network.HTTP.Types.Method            ( methodGet, methodPost, methodHead, methodDelete )
 import Network.Wai.Middleware.Cors          ( cors
                                             , simpleCorsResourcePolicy
@@ -116,7 +116,7 @@ server config@Config{..} =
             ]
 
         , corsOrigins = Just
-            ( [_configClientAddress], True )
+            ( [toS _configClientAddress], True )
 
         , corsMethods =
             [ methodGet

--- a/src/app/Server.hs
+++ b/src/app/Server.hs
@@ -102,7 +102,7 @@ implAPI =
 
 -- Create a Servant Server to run in WAI.
 server :: Config -> Application
-server config =
+server config@Config{..} =
   logStdout
     $ corsHandler
     $ serve proxyAPI
@@ -112,12 +112,11 @@ server config =
     corsHandler =
       cors . const $ Just $ simpleCorsResourcePolicy
         { corsRequestHeaders =
-            [ "Authorization"
-            , "Content-Type"
+            [ "Content-Type"
             ]
 
         , corsOrigins = Just
-            ( ["http://localhost:3000"], True )
+            ( [_configClientAddress], True )
 
         , corsMethods =
             [ methodGet

--- a/src/app/Server.hs
+++ b/src/app/Server.hs
@@ -8,7 +8,7 @@ module Server
 import Protolude
 import Servant
 
-import Configuration                        ( Config )
+import Configuration                        ( Config(..) )
 import Network.HTTP.Types.Method            ( methodGet, methodPost, methodHead, methodDelete )
 import Network.Wai.Middleware.Cors          ( cors
                                             , simpleCorsResourcePolicy


### PR DESCRIPTION
Origin was fixed as localhost:3000, which broke live.